### PR TITLE
small fix read description

### DIFF
--- a/PreviewService.Core/Services/PreviewService.cs
+++ b/PreviewService.Core/Services/PreviewService.cs
@@ -29,7 +29,7 @@ namespace PreviewService.Core.Services
         {
             // If the requests paths is null or any of the paths are empty, 
             // return an empty ResultPreview
-            if (request.path == null || request.path.Any(x => x == ""))
+            if (request.path == null || request.path.Any(x => string.IsNullOrEmpty(x)))
                 return new ResultPreview();
 
             var previews = request.path.AsParallel().Select(async p =>


### PR DESCRIPTION
PreviewService returns empty ResultPreview if an item in the array is now also null.